### PR TITLE
Setup GitHub Actions for README auto-deployment to GitHub Pages

### DIFF
--- a/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
+++ b/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
@@ -1,0 +1,34 @@
+name: Deploy to GitHub Pages
+
+on:
+  push:
+    branches:
+      - main
+    paths:
+      - README.md
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v2
+
+    - name: Setup Node.js
+      uses: actions/setup-node@v2
+      with:
+        node-version: '16'
+
+    - name: Generate index.html from README
+      run: |
+        echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>README</title></head><body>' > index.html
+        cat README.md | markdown >> index.html
+        echo '</body></html>' >> index.html
+
+    - name: Deploy to GitHub Pages
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./
+        keep_files: false

--- a/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
+++ b/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
@@ -26,9 +26,21 @@ jobs:
           cat README.md | markdown >> index.html
           echo '</body></html>' >> index.html
 
-      - name: Deploy to GitHub Pages
-        uses: peaceiris/actions-gh-pages@v3
+      - name: Setup Pages
+        uses: actions/configure-pages@v5
+
+      - name: Upload artifact
+        uses: actions/upload-pages-artifact@v3
         with:
-          github_token: ${{ secrets.GITHUB_TOKEN }}
-          publish_dir: ./
-          keep_files: false
+          path: index.html
+
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    needs: build-and-deploy
+    steps:
+      - name: Deploy to GitHub Pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
+++ b/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
@@ -8,27 +8,27 @@ on:
       - README.md
 
 jobs:
-  deploy:
+  build-and-deploy:
     runs-on: ubuntu-latest
 
     steps:
-    - name: Checkout repository
-      uses: actions/checkout@v2
+      - name: Checkout repository
+        uses: actions/checkout@v2
 
-    - name: Setup Node.js
-      uses: actions/setup-node@v2
-      with:
-        node-version: '16'
+      - name: Setup Node.js
+        uses: actions/setup-node@v2
+        with:
+          node-version: '16'
 
-    - name: Generate index.html from README
-      run: |
-        echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>README</title></head><body>' > index.html
-        cat README.md | markdown >> index.html
-        echo '</body></html>' >> index.html
+      - name: Convert README to HTML
+        run: |
+          echo '<!DOCTYPE html><html><head><meta charset="utf-8"><title>README</title></head><body>' > index.html
+          cat README.md | markdown >> index.html
+          echo '</body></html>' >> index.html
 
-    - name: Deploy to GitHub Pages
-      uses: peaceiris/actions-gh-pages@v3
-      with:
-        github_token: ${{ secrets.GITHUB_TOKEN }}
-        publish_dir: ./
-        keep_files: false
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v3
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./
+          keep_files: false

--- a/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
+++ b/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
@@ -6,15 +6,14 @@ on:
       - main
     paths:
       - README.md
-      
-permissions:
-  contents: read
-  pages: write
-  id-token: write
-  
+
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+
+    permissions:
+      contents: read
+
     concurrency:
       group: "pages"
       cancel-in-progress: true
@@ -48,6 +47,15 @@ jobs:
       url: ${{ steps.deployment.outputs.page_url }}
     runs-on: ubuntu-latest
     needs: build-and-deploy
+
+    permissions:
+      pages: write
+      id-token: write
+
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
+
     steps:
       - name: Deploy to GitHub Pages
         id: deployment

--- a/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
+++ b/.github/ISSUE_TEMPLATE/workflows/deploy.yaml
@@ -6,10 +6,18 @@ on:
       - main
     paths:
       - README.md
-
+      
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+  
 jobs:
   build-and-deploy:
     runs-on: ubuntu-latest
+    concurrency:
+      group: "pages"
+      cancel-in-progress: true
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
Hi @fhinkel 

This pull request adds a GitHub Actions workflow to automatically publish changes from the `README.md` to GitHub Pages. The workflow is triggered on pushes to the `main` branch that include changes to the `README.md`. It converts the `README.md` into an `index.html` and deploys it.

### Changes:
- Created `.github/workflows/deploy.yml` to define the GitHub Actions workflow.
- The workflow checks out the code, converts the `README.md` to `index.html`, and deploys it using `peaceiris/actions-gh-pages`.

Resolves #22 